### PR TITLE
nebula-css License added

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,27 @@ v. Some widgets are available under theme/inc/widgets (see function activation)
 ```
 https://github.com/REPTILEHAUS/CHAMELEON_ONE/issues
 ```
+
+# Legal
+#### nebula-css
+    The MIT License (MIT)
+    
+    Copyright (c) 2017 Robert Smith
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -145,27 +145,3 @@ v. Some widgets are available under theme/inc/widgets (see function activation)
 ```
 https://github.com/REPTILEHAUS/CHAMELEON_ONE/issues
 ```
-
-# Legal
-#### nebula-css
-    The MIT License (MIT)
-    
-    Copyright (c) 2017 Robert Smith
-    
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-    
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-    
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "grunt",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "help": "grunt --help"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "autoprefixer": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "start": "grunt",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "help": "grunt --help"
   },
   "dependencies": {
     "autoprefixer": "^7.1.1",


### PR DESCRIPTION
#1 

You should add the license if you are using a modified version of nebula-css. That's what the MIT License requires.